### PR TITLE
feat: Promote argocd/argocd release to 8.0.2 in docker-stable

### DIFF
--- a/.github/workflows/diff.yaml
+++ b/.github/workflows/diff.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup yq
         uses: fluxcd/pkg/actions/yq@main
       - name: Setup kustomize

--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -154,7 +154,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "8.0.1"
+      version: "8.0.2"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -38,8 +38,7 @@ for cluster_path in "$CLUSTERS_DIR"/*/; do
 done
 
 git fetch --all
-git switch main
-git merge origin/main
+git checkout -f main &> /dev/null
 
 for cluster_path in "$CLUSTERS_DIR"/*/; do
   # Remove trailing slash and get the cluster name
@@ -57,7 +56,7 @@ for cluster_path in "$CLUSTERS_DIR"/*/; do
   cd - > /dev/null
 done
 
-git checkout -f "$current_branch" #&> /dev/null
+git checkout -f "$current_branch" &> /dev/null
 
 for cluster_path in "$CLUSTERS_DIR"/*/; do
   cluster_name=$(basename "$cluster_path")

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -38,7 +38,7 @@ for cluster_path in "$CLUSTERS_DIR"/*/; do
 done
 
 git fetch --all
-git checkout -f main #&> /dev/null
+git checkout -f originmain #&> /dev/null
 
 for cluster_path in "$CLUSTERS_DIR"/*/; do
   # Remove trailing slash and get the cluster name

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -38,7 +38,7 @@ for cluster_path in "$CLUSTERS_DIR"/*/; do
 done
 
 git fetch --all
-git checkout -f originmain #&> /dev/null
+git checkout -f origin/main #&> /dev/null
 
 for cluster_path in "$CLUSTERS_DIR"/*/; do
   # Remove trailing slash and get the cluster name

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -38,7 +38,8 @@ for cluster_path in "$CLUSTERS_DIR"/*/; do
 done
 
 git fetch --all
-git checkout -f origin/main #&> /dev/null
+git switch main
+git merge origin/main
 
 for cluster_path in "$CLUSTERS_DIR"/*/; do
   # Remove trailing slash and get the cluster name


### PR DESCRIPTION
**Automated PR**
HelmRelease argocd/argocd was upgraded from 8.0.1 to version 8.0.2 in docker-flex.
Promote to stable.