### PR TITLE
feat: Promote keda/keda release to 2.17.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -64,7 +64,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "2.17.0"
+      version: "2.17.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease keda/keda was upgraded from 2.17.0 to version 2.17.1 in docker-flex.
Promote to stable.