### PR TITLE
feat: Promote pgadmin/pgadmin4 release to 1.45.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -174,7 +174,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.44.0"
+      version: "1.45.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease pgadmin/pgadmin4 was upgraded from 1.44.0 to version 1.45.1 in docker-flex.
Promote to stable.