### PR TITLE
feat: Promote victoria-logs/vls release to 0.11.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -283,7 +283,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.10.0"
+      version: "0.11.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease victoria-logs/vls was upgraded from 0.10.0 to version 0.11.1 in docker-flex.
Promote to stable.