### PR TITLE
feat: Promote cert-manager/cert-manager release to v1.18.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -114,7 +114,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "v1.17.2"
+      version: "v1.18.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease cert-manager/cert-manager was upgraded from v1.17.2 to version v1.18.0 in docker-flex.
Promote to stable.