### PR TITLE
feat: Promote argocd/argocd release to 8.0.17 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -154,7 +154,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "8.0.16"
+      version: "8.0.17"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease argocd/argocd was upgraded from 8.0.16 to version 8.0.17 in docker-flex.
Promote to stable.