### PR TITLE
feat: Promote seaweedfs/seaweedfs release to 4.0.391 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -263,7 +263,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "4.0.390"
+      version: "4.0.391"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease seaweedfs/seaweedfs was upgraded from 4.0.390 to version 4.0.391 in docker-flex.
Promote to stable.