### PR TITLE
feat: Promote cert-manager/cert-manager release to v1.18.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -114,7 +114,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "v1.18.0"
+      version: "v1.18.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease cert-manager/cert-manager was upgraded from v1.18.0 to version v1.18.1 in docker-flex.
Promote to stable.