### PR TITLE
feat: Promote keda/keda release to 2.17.2 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -64,7 +64,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "2.17.1"
+      version: "2.17.2"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease keda/keda was upgraded from 2.17.1 to version 2.17.2 in docker-flex.
Promote to stable.