### PR TITLE
feat: Promote istio-ingress/istio-ingress-private release to 1.26.2 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -84,7 +84,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.26.1"
+      version: "1.26.2"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease istio-ingress/istio-ingress-private was upgraded from 1.26.1 to version 1.26.2 in docker-flex.
Promote to stable.