### PR TITLE
feat: Promote x509-certificate-exporter/x509-certificate-exporter release to 3.19.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -243,7 +243,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "3.18.1"
+      version: "3.19.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease x509-certificate-exporter/x509-certificate-exporter was upgraded from 3.18.1 to version 3.19.1 in docker-flex.
Promote to stable.