### PR TITLE
feat: Promote reloader/reloader release to 2.1.4 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -253,7 +253,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "2.1.3"
+      version: "2.1.4"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease reloader/reloader was upgraded from 2.1.3 to version 2.1.4 in docker-flex.
Promote to stable.