### PR TITLE
feat: Promote kyverno/kyverno release to 3.4.3 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -293,4 +293,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: "3.4.2"
+      version: "3.4.3"


### PR DESCRIPTION
**Automated PR**
HelmRelease kyverno/kyverno was upgraded from 3.4.2 to version 3.4.3 in docker-flex.
Promote to stable.