### PR TITLE
feat: Promote monitoring/victoria-metrics-k8s-stack release to 0.54.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.52.0"
+      version: "0.54.0"
   values:
     prometheus-node-exporter:
       hostRootFsMount:


### PR DESCRIPTION
**Automated PR**
HelmRelease monitoring/victoria-metrics-k8s-stack was upgraded from 0.52.0 to version 0.54.0 in docker-flex.
Promote to stable.