### PR TITLE
feat: Promote external-secrets/external-secrets release to 0.18.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -134,7 +134,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.18.0"
+      version: "0.18.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease external-secrets/external-secrets was upgraded from 0.18.0 to version 0.18.1 in docker-flex.
Promote to stable.