### PR TITLE
feat: Promote reflector/reflector release to 9.1.14 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -124,7 +124,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "9.1.13"
+      version: "9.1.14"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease reflector/reflector was upgraded from 9.1.13 to version 9.1.14 in docker-flex.
Promote to stable.