### PR TITLE
feat: Promote kyverno/kyverno release to 3.4.4 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -293,7 +293,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "3.4.3"
+      version: "3.4.4"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease kyverno/kyverno was upgraded from 3.4.3 to version 3.4.4 in docker-flex.
Promote to stable.