### PR TITLE
feat: Promote blackbox-exporter/blackbox-exporter release to 11.0.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -54,7 +54,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "9.4.0"
+      version: "11.0.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease blackbox-exporter/blackbox-exporter was upgraded from 9.4.0 to version 11.0.0 in docker-flex.
Promote to stable.