### PR TITLE
feat: Promote clickhouse-operator/clickhouse-operator release to 0.25.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -273,7 +273,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.25.0"
+      version: "0.25.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease clickhouse-operator/clickhouse-operator was upgraded from 0.25.0 to version 0.25.1 in docker-flex.
Promote to stable.