### PR TITLE
feat: Promote jenkins/jenkins release to 5.8.64 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -144,7 +144,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "5.8.62"
+      version: "5.8.64"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease jenkins/jenkins was upgraded from 5.8.62 to version 5.8.64 in docker-flex.
Promote to stable.