### PR TITLE
feat: Promote airflow/airflow release to 1.18.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -184,7 +184,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.17.0"
+      version: "1.18.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease airflow/airflow was upgraded from 1.17.0 to version 1.18.0 in docker-flex.
Promote to stable.