### PR TITLE
feat: Promote metrics-server/metrics-server release to 3.13.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "3.12.2"
+      version: "3.13.0"
   values:
     args:
       - --kubelet-insecure-tls


### PR DESCRIPTION
**Automated PR**
HelmRelease metrics-server/metrics-server was upgraded from 3.12.2 to version 3.13.0 in docker-flex.
Promote to stable.