### PR TITLE
feat: Promote elastic-system/elastic-operator release to 3.1.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -233,7 +233,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "3.0.0"
+      version: "3.1.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease elastic-system/elastic-operator was upgraded from 3.0.0 to version 3.1.0 in docker-flex.
Promote to stable.