### PR TITLE
feat: Promote blackbox-exporter/blackbox-exporter release to 11.2.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -54,7 +54,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "11.1.1"
+      version: "11.2.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease blackbox-exporter/blackbox-exporter was upgraded from 11.1.1 to version 11.2.0 in docker-flex.
Promote to stable.