### PR TITLE
feat: Promote monitoring/victoria-metrics-k8s-stack release to 0.58.3 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.58.2"
+      version: "0.58.3"
   values:
     prometheus-node-exporter:
       hostRootFsMount:


### PR DESCRIPTION
**Automated PR**
HelmRelease monitoring/victoria-metrics-k8s-stack was upgraded from 0.58.2 to version 0.58.3 in docker-flex.
Promote to stable.