### PR TITLE
feat: Promote apache-superset/apache-superset release to 0.15.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -304,4 +304,4 @@ spec:
   releaseName: apache-superset
   chart:
     spec:
-      version: "0.14.3"
+      version: "0.15.0"


### PR DESCRIPTION
**Automated PR**
HelmRelease apache-superset/apache-superset was upgraded from 0.14.3 to version 0.15.0 in docker-flex.
Promote to stable.