### PR TITLE
feat: Promote cnpg-system/cnpg release to 0.26.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -104,7 +104,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.25.0"
+      version: "0.26.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease cnpg-system/cnpg was upgraded from 0.25.0 to version 0.26.0 in docker-flex.
Promote to stable.