### PR TITLE
feat: Promote kubelinks/kubelinks release to 0.4.12 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.4.10"
+      version: "0.4.12"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease kubelinks/kubelinks was upgraded from 0.4.10 to version 0.4.12 in docker-flex.
Promote to stable.