### PR TITLE
feat: Promote pgadmin/pgadmin4 release to 1.49.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -174,7 +174,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.48.0"
+      version: "1.49.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease pgadmin/pgadmin4 was upgraded from 1.48.0 to version 1.49.0 in docker-flex.
Promote to stable.