### PR TITLE
feat: Promote victoria-logs/vls release to 0.11.7 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -283,7 +283,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.11.6"
+      version: "0.11.7"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease victoria-logs/vls was upgraded from 0.11.6 to version 0.11.7 in docker-flex.
Promote to stable.