### PR TITLE
feat: Promote istio-system/istiod release to 1.27.1 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -74,7 +74,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.27.0"
+      version: "1.27.1"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease istio-system/istiod was upgraded from 1.27.0 to version 1.27.1 in docker-flex.
Promote to stable.