### PR TITLE
feat: Promote clickhouse-operator/clickhouse-operator release to 0.25.4 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -273,7 +273,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.25.3"
+      version: "0.25.4"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease clickhouse-operator/clickhouse-operator was upgraded from 0.25.3 to version 0.25.4 in docker-flex.
Promote to stable.