### PR TITLE
feat: Promote alloy/alloy release to 1.3.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -223,7 +223,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "1.2.1"
+      version: "1.3.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease alloy/alloy was upgraded from 1.2.1 to version 1.3.0 in docker-flex.
Promote to stable.