### PR TITLE
feat: Promote strimzi/strimzi-kafka-operator release to 0.48.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -164,7 +164,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "0.47.0"
+      version: "0.48.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
**Automated PR**
HelmRelease strimzi/strimzi-kafka-operator was upgraded from 0.47.0 to version 0.48.0 in docker-flex.
Promote to stable.