### PR TITLE
feat: Promote loki/loki release to 6.42.0 in docker-stable

### DIFF
--- a/apps/bundles/docker-stable/docker-stable.yaml
+++ b/apps/bundles/docker-stable/docker-stable.yaml
@@ -204,7 +204,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "6.41.1"
+      version: "6.42.0"
   values:
     gateway:
       affinity:


### PR DESCRIPTION
**Automated PR**
HelmRelease loki/loki was upgraded from 6.41.1 to version 6.42.0 in docker-flex.
Promote to stable.