### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Flux2 Infra repository
 
 This repository provides a collection of infrastructure applications and add-ons intended for deployment within Kubernetes clusters using FluxCD.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 
 **Note**: This repository serves as a boilerplate and reference implementation. All configurations should be reviewed, adapted, and validated based on your specific requirements and environment. **Do not** deploy this setup directly into production without proper customization and testing.
 


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*